### PR TITLE
Initial version of the filescan go module

### DIFF
--- a/docs/_detail.md
+++ b/docs/_detail.md
@@ -1,26 +1,22 @@
 #### What is the Go Kit?
 
-Lorem ipsum dolor sit amet, sed ad atqui mnesarchum, autem luptatum honestatis ea nam.
-Sea no error soluta, mei te tollit nullam nominati. Sea debitis officiis no. Te iracundia conceptam duo.  
-
+A go module(`secplugs.com/filescan`) that can be readily integrated into your code base to submit data for malware scan
+Currently the plugin supports file scans
 
 #### What are the features?
 
-- __File scanning__ - Scan files and directories for malware.
-- __URL scanning__ - Send urls for analysis.
-- __Realy simply to use__ - Works out of the box with the anonymous free tier usage.
+- __File Scanning__ - Easy methods to allow uploading of files for scanning
 - __Secplugs Portal__ - With a registered API key you can access all the core Secplugs features via the portal.
 
 #### How does it work?
 
-Lorem ipsum dolor sit amet, sed ad atqui mnesarchum, autem luptatum honestatis ea nam.
-Sea no error soluta, mei te tollit nullam nominati. Sea debitis officiis no. Te iracundia conceptam duo.  
+The library supports all the standard Secplugs functionality allowing access to file analysis functionality and makes it easier than integrating directly with the REST APIs.
 
 #### How do I get started?
 
-Lorem ipsum dolor sit amet, sed ad atqui mnesarchum, autem luptatum honestatis ea nam.
-Sea no error soluta, mei te tollit nullam nominati. Sea debitis officiis no. Te iracundia conceptam duo.  
+To get started download the module (via `go get secplugs.com/filescan`) and use it in your Go code. This will work out of the box.
 
-Lorem ipsum dolor sit amet, sed ad atqui mnesarchum, autem luptatum honestatis ea nam.
-Sea no error soluta, mei te tollit nullam nominati. Sea debitis officiis no. Te iracundia conceptam duo.  
+To use additional features and the privacy of your own account, after registering in Secplugs.com, login with your username and create an API key to use with your Go code. 
+Create a new instance of the scan client with the API key and use it in your code.
+Use can then use the Secplugs console to view activity, run reports and do deeper retrospective threat analysis.
 

--- a/docs/_summary.md
+++ b/docs/_summary.md
@@ -1,4 +1,3 @@
-Working scripts and tools written in Go ready to use as is or extend.  
-For example, upload files for scanning or grepping logs for URLs for scanning. 
-  
-The scripts are up open source on GitHub and contain ample comments, so you can fork them and modify as you wish.
+A Secplugs powered, ready to use tooling written in Go.
+
+The plugin is open source so you can modify as you wish.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,24 @@
 {% include_relative _detail.md %}
 
 ## Quick Start
-Quick start
+Obtain the go module by simply running the commands below.
+```console
+GO111MODULE=on go get secplugs.com/filescan
+```
+You'll now have the module in your `$GOPATH`
 
 ## Usage
-Usage description
+Here, a very simple example of how to integrate file scan with your go code base is provided
+{% include_relative usage.md %}
+
+To avail yourself of the complete set of vendors and features provided by secplugs, and to have complete privacy
+for the scans you submit, please create an accout at secplugs.com, login to the portal and create a new API key.
+Please not that this API key is confidential.
+
+After registering with secplugs.com and creating an API key, the only change to the code sample about would be
+{% include_relative registered_usage.md %}
+
+Everything else remains the same.
 
 ## Contact
 Having trouble? [Contact Secplugs ](https://secplugs.com/contacts)

--- a/docs/registered_usage.md
+++ b/docs/registered_usage.md
@@ -1,0 +1,3 @@
+```
+client := filescan.NewScanClient{"my-api-key"}
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,23 +1,21 @@
-### url_scan.sh - Url Analysis Script
-Use this script for submitting urls for analysis
-To scan a url, pass it as a parameter  
-E.g. below shows scanning of a Secplugs test url
-```sh
-./url_scan.sh https://example.com/?param=e81e043973f21d036e39fe
 ```
-### file_scan.sh - File Analysis Script
-Use this script for submitting files for analysis
-To test connectivity run without no argument, it will default to scanning eicar.  
-```sh
-./file_scan.sh
-```
-To scan a named file, pass the file as a parameter  
-E.g. to have it scan itself use below.
-```sh
-./file_scan.sh ./file_scan.sh
-```
-To scan the contents of named directory, specify a directory as parameter
-E.g. to scan the contents of the /tmp
-```sh
-./file_scan.sh /tmp
+package main
+
+import (
+        "fmt"
+        "log"
+
+        "secplugs.com/filescan"
+)
+
+func main() {
+	fmt.Println("Using secplugs.com filescan")
+	client := filescan.NewDefaultScanClient()
+
+	result, err := client.ScanFile("/path/to/file/to/be/scanned")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%d is the score", result.Score)
+}
 ```

--- a/filescan/fileupload.go
+++ b/filescan/fileupload.go
@@ -1,0 +1,203 @@
+// Package filescan provides the basic methods and functions required to
+// scan a file at secplugs.com.
+package filescan
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// UploadInfo represents the Object form of the JSON response returned by the
+// /file/upload API meant to upload a file for malware scan.
+type UploadInfo struct {
+	UploadPost struct {
+		URL    string `json:"url"`
+		Fields struct {
+			Key               string `json:"key"`
+			XAmzAlgorithm     string `json:"x-amz-algorithm"`
+			XAmzCredential    string `json:"x-amz-credential"`
+			XAmzDate          string `json:"x-amz-date"`
+			XAmzSecurityToken string `json:"x-amz-security-token"`
+			Policy            string `json:"policy"`
+			XAmzSignature     string `json:"x-amz-signature"`
+		} `json:"fields"`
+	} `json:"upload_post"`
+}
+
+// NewScanClient creates a new ScanClient with the specified API key.
+// The API key can be created and obtained from the Secplugs portal.
+func NewScanClient(api string) *ScanClient {
+	client := &ScanClient{}
+	client.ApiKey = api
+	return client
+}
+
+// NewDefaultScanClient creates a new ScanClient with the default API key.
+// No choice of vendors and limited features available with this API key.
+func NewDefaultScanClient() *ScanClient {
+	client := &ScanClient{}
+	client.ApiKey = SECPLUGS_DEFAULT_API_KEY
+	return client
+}
+
+// ScanFile is the high-level to submit a file to Secplugs for a quickscan.
+// It generates a pre-signed URL, uploads the file to that URL and the triggers
+// a quick scan.
+func (client *ScanClient) ScanFile(filename string) (ScanResult, error) {
+	client.FileName = filename
+	cksum, err := client.CalculateChecksum(filename)
+	if err != nil {
+		return ScanResult{}, err
+	}
+
+	client.UniqueId = cksum
+	info, err := client.GetPresignedUrl(cksum)
+	if err != nil {
+		return ScanResult{}, err
+	}
+
+	fields, err := info.GetFields()
+	if err != nil {
+		return ScanResult{}, err
+	}
+	url := info.GetUrl()
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	for k, v := range fields {
+		fw, _ := writer.CreateFormField(k)
+		fw.Write([]byte(v))
+	}
+	file, _ := os.Open(filename)
+	part, _ := writer.CreateFormFile("file", filepath.Base(file.Name()))
+	io.Copy(part, file)
+	httpclient := &http.Client{}
+	writer.Close()
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	req.Header.Add("Content-Type", writer.FormDataContentType())
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		return ScanResult{}, err
+	}
+
+	if resp.StatusCode >= 300 {
+		return ScanResult{}, &HTTPResponseStatusError{resp.StatusCode, "Error"}
+	} else {
+		result, err := client.QuickScan()
+		if err != nil {
+			return ScanResult{}, err
+		}
+		return result, nil
+	}
+}
+
+// CalculateChecksum generates the SHA256 sum for a file. It is meant for internal consumption by
+// the ScanFile API. But this can also used by clients using the other low-level APIs.
+func (client *ScanClient) CalculateChecksum(filename string) (string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return "", &ChecksumGenerationError{}
+	}
+	defer f.Close()
+
+	sha256sum := sha256.New()
+	if _, err := io.Copy(sha256sum, f); err != nil {
+		return "", &ChecksumGenerationError{}
+	}
+	return fmt.Sprintf("%x", sha256sum.Sum(nil)), nil
+}
+
+// GetPresignedUrl is used to obtain an upload URL and some unique fields to subsequenly upload
+// a file for analysis. This is a low-level API and can be used by clients that do not want to
+// use the high-level ScanFile API.
+func (client *ScanClient) GetPresignedUrl(cksum string) (UploadInfo, error) {
+	secplugsBaseUrl := SECPLUGS_API_FILE_UPLOAD_URL + "?sha256=" + cksum
+	httpclient := &http.Client{}
+	req, err := http.NewRequest("GET", secplugsBaseUrl, nil)
+	if err != nil {
+		return UploadInfo{}, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("x-api-key", client.ApiKey)
+	resp, err := httpclient.Do(req)
+	if err != nil {
+		return UploadInfo{}, err
+	}
+	defer resp.Body.Close()
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return UploadInfo{}, err
+	}
+	var info UploadInfo
+	jsonerr := json.Unmarshal(respBytes, &info)
+	if jsonerr != nil {
+		return UploadInfo{}, jsonerr
+	}
+	return info, nil
+}
+
+func (info UploadInfo) GetFields() (map[string]string, error) {
+	b, _ := json.Marshal(info.UploadPost.Fields)
+	fields := make(map[string]string)
+	err := json.Unmarshal(b, &fields)
+	if err != nil {
+		return fields, err
+	}
+	return fields, nil
+}
+
+func (info UploadInfo) GetUrl() string {
+	return info.UploadPost.URL
+}
+
+// QuickScan performs a Secplugs file quickscan, which is sufficient for most
+// usecases of a file scan. The most common type of file scans at Secplugs.
+func (client *ScanClient) QuickScan() (ScanResult, error) {
+	scanContext := map[string]string{
+		"filename":    client.FileName,
+		"client_uuid": "test-uuid",
+	}
+	ctxt, err := json.Marshal(scanContext)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	url := SECPLUGS_API_FILE_QUICKSCAN
+	sha256 := client.UniqueId
+
+	httpClient := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	req.Header.Add("x-api-key", client.ApiKey)
+	q := req.URL.Query()
+	q.Add("sha256", sha256)
+	q.Add("scancontext", string(ctxt))
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	defer resp.Body.Close()
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return ScanResult{}, err
+	}
+	var result ScanResult
+	jsonerr := json.Unmarshal(respBytes, &result)
+	if jsonerr != nil {
+		return ScanResult{}, jsonerr
+	}
+	return result, nil
+}

--- a/filescan/fileupload_test.go
+++ b/filescan/fileupload_test.go
@@ -1,0 +1,36 @@
+package filescan_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"secplugs.com/filescan"
+)
+
+func TestNewDefaultScanClient(t *testing.T) {
+	client := filescan.NewDefaultScanClient()
+	if client.ApiKey != "r2iKI4q7Lu91Nu5uPl3eW3BPmRo4XK1ZbhLWtOKd" {
+		t.Errorf("ApiKey is incorrect: %s", client.ApiKey)
+	}
+}
+
+func TestNewScanClient(t *testing.T) {
+	client := filescan.NewScanClient("testapikey")
+	if client.ApiKey != "testapikey" {
+		t.Errorf("ApiKey is incorrect: %s", client.ApiKey)
+	}
+}
+
+func ExampleScanFile() {
+	client := filescan.NewDefaultScanClient()
+	filename, err := filepath.Abs(os.Args[0])
+	result, err := client.ScanFile(filename)
+	if err != nil {
+		fmt.Printf("Error scanning file: %v\n", err)
+	}
+	fmt.Printf("Score: %d\n", result.Score)
+	// Output:
+	// Score: 70
+}

--- a/filescan/go.mod
+++ b/filescan/go.mod
@@ -1,0 +1,3 @@
+module secplugs.com/filescan
+
+go 1.16

--- a/filescan/restclient.go
+++ b/filescan/restclient.go
@@ -1,0 +1,5 @@
+package filescan
+
+func CheckResult() bool {
+	return true
+}

--- a/filescan/scanerror.go
+++ b/filescan/scanerror.go
@@ -1,0 +1,18 @@
+package filescan
+
+import "fmt"
+
+type HTTPResponseStatusError struct {
+	code int
+	msg  string
+}
+
+func (e *HTTPResponseStatusError) Error() string {
+	return fmt.Sprintf("%d %s", e.code, e.msg)
+}
+
+type ChecksumGenerationError struct{}
+
+func (e *ChecksumGenerationError) Error() string {
+	return "Error computing the checksum"
+}

--- a/filescan/scanner.go
+++ b/filescan/scanner.go
@@ -1,0 +1,14 @@
+package filescan
+
+// ScanClient is the struct on which all scan features are defined.
+type ScanClient struct {
+	ApiKey   string
+	Vendor   string
+	FileName string
+	UniqueId string
+}
+
+const SECPLUGS_API_BASE_URL string = "https://api.live.secplugs.com/security"
+const SECPLUGS_API_FILE_UPLOAD_URL string = SECPLUGS_API_BASE_URL + "/file/upload"
+const SECPLUGS_API_FILE_QUICKSCAN string = SECPLUGS_API_BASE_URL + "/file/quickscan"
+const SECPLUGS_DEFAULT_API_KEY string = "r2iKI4q7Lu91Nu5uPl3eW3BPmRo4XK1ZbhLWtOKd"

--- a/filescan/scanresult.go
+++ b/filescan/scanresult.go
@@ -1,0 +1,66 @@
+package filescan
+
+type ScanResult struct {
+	Score        int    `json:"score"`
+	JSONReport   string `json:"json_report"`
+	ThreatObject struct {
+		Sha256 string `json:"sha256"`
+	} `json:"threat_object"`
+	ScanContext struct {
+	} `json:"scan_context"`
+	Datetime  float64 `json:"datetime"`
+	Status    string  `json:"status"`
+	AccountID string  `json:"account_id"`
+	APIKey    string  `json:"api_key"`
+	MetaData  struct {
+		PluginInfo struct {
+			Type string `json:"type"`
+			Name string `json:"name"`
+		} `json:"plugin_info"`
+		Capability string `json:"capability"`
+		VendorInfo struct {
+			VendorConfigName string `json:"vendor_config_name"`
+			EntitlementLevel string `json:"entitlement_level"`
+			Vendor           string `json:"vendor"`
+			Credits          int    `json:"credits"`
+			Params           struct {
+			} `json:"params"`
+		} `json:"vendor_info"`
+	} `json:"meta_data"`
+	ReportID string  `json:"report_id"`
+	Verdict  string  `json:"verdict"`
+	Duration float64 `json:"duration"`
+}
+
+type ProxyScanResult struct {
+	Score        int    `json:"score"`
+	JSONReport   string `json:"json_report"`
+	ThreatObject struct {
+		Sha256 string `json:"sha256"`
+	} `json:"threat_object"`
+	ScanContext struct {
+	} `json:"scan_context"`
+	Datetime  float64 `json:"datetime"`
+	Status    string  `json:"status"`
+	AccountID string  `json:"account_id"`
+	APIKey    string  `json:"api_key"`
+	MetaData  struct {
+		PluginInfo struct {
+			Type string `json:"type"`
+			Name string `json:"name"`
+		} `json:"plugin_info"`
+		Capability string `json:"capability"`
+		VendorInfo struct {
+			VendorConfigName string `json:"vendor_config_name"`
+			EntitlementLevel string `json:"entitlement_level"`
+			Vendor           string `json:"vendor"`
+			Credits          int    `json:"credits"`
+			Params           struct {
+			} `json:"params"`
+		} `json:"vendor_info"`
+	} `json:"meta_data"`
+	ReportID      string  `json:"report_id"`
+	Verdict       string  `json:"verdict"`
+	Duration      float64 `json:"duration"`
+	UserReportURL string  `json:"user_report_url"`
+}


### PR DESCRIPTION
This supports the scanning of a file for malware via either the default api
key or a registered api key. This module can be installed the usual way by
`go get secplugs.com/filescan`.

The docs have been updated. But might have to go through a couple of iterations
to get it right.