### PR TITLE
Fix the module naming

### DIFF
--- a/filescan/fileupload_test.go
+++ b/filescan/fileupload_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"secplugs.com/filescan"
+	"github.com/secplugs/go-kit/filescan"
 )
 
 func TestNewDefaultScanClient(t *testing.T) {

--- a/filescan/go.mod
+++ b/filescan/go.mod
@@ -1,3 +1,3 @@
-module secplugs.com/filescan
+module github.com/secplugs/go-kit/filescan
 
 go 1.16


### PR DESCRIPTION
go get pulls the module from github. So, rename it accordingly.